### PR TITLE
CI Improvements, from sylabs 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,16 @@
 version: 2.1
 
-defaults: &defaults
-  docker:
-    - image: python:3.9-buster
-
-jobs:
-
-  lint_markdown:
-    <<: *defaults
+executors:
+  node:
     docker:
       - image: node:14
+  python:
+    docker:
+      - image: python:3.9-buster
+
+jobs:
+  lint_markdown:
+    executor: node
     steps:
       - checkout
       - run:
@@ -20,7 +21,7 @@ jobs:
           command: markdownlint .
 
   check_rst:
-    <<: *defaults
+    executor: python
     steps:
       - checkout
       - run:
@@ -33,7 +34,7 @@ jobs:
             rstcheck --ignore-language c,c++ --report warning *.rst
 
   make_html:
-    <<: *defaults
+    executor: python
     steps:
       - checkout
       - run:
@@ -65,7 +66,7 @@ jobs:
           destination: html
 
   make_pdf_epub:
-    <<: *defaults
+    executor: python
     steps:
       - checkout
       - run:
@@ -119,4 +120,3 @@ workflows:
       - make_pdf_epub:
           requires:
             - check_rst
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   node:
     docker:
-      - image: node:14
+      - image: node:16
   python:
     docker:
       - image: python:3.9-buster


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity-userdocs#2

The original PR description was:

> Use [reusable executors](https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-executors) instead of YAML anchors in CircleCI config. Bump `node` from 14.x to 16.x.