### PR TITLE
Update environment_and_metadata.rst, from sylabs 23

### DIFF
--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -659,10 +659,10 @@ And the output would look like:
 
 
 ^^^^^^^^^^^^^^^^^^^^^^^
-``-h`` / ``--helpfile``
+``-H`` / ``--helpfile``
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``-h`` or ``-helpfile`` flag will show the container's description
+The ``-H`` or ``-helpfile`` flag will show the container's description
 in the ``%help`` section of its definition file.
 
 You can call it this way:


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity-userdocs#23

The original PR description was:

> To display the %help section of the definition file, a capital H is needed '-H'